### PR TITLE
SOF-24511 - The getdown launcher now moves the getdown.txt file to getdown.txt_old after launching the app.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*/target/
 /target/
 core/src/main/java/com/threerings/getdown/data/Build.java
+/.idea

--- a/core/src/main/java/com/threerings/getdown/data/Application.java
+++ b/core/src/main/java/com/threerings/getdown/data/Application.java
@@ -269,6 +269,24 @@ public class Application
         return config;
     }
 
+    /**
+     * Invalidates the {@code getdown.txt} config file.
+     */
+    public static void invalidateConfig(String appDir) {
+        File cfgfile = new File(appDir, CONFIG_FILE);
+        if (cfgfile.exists()) {
+            File cfgfileUsed = new File(appDir, CONFIG_FILE + "_old");
+            if (cfgfileUsed.exists() && cfgfileUsed.delete()) {
+                log.info("Removed old " + CONFIG_FILE);
+            }
+            if (cfgfile.renameTo(cfgfileUsed)) {
+                log.info("Moved " + CONFIG_FILE + " to " + CONFIG_FILE + "_old");
+            } else {
+                log.error("Failed to rename " + CONFIG_FILE + " to " + CONFIG_FILE + "_old");
+            }
+        }
+    }
+
     /** A helper that is used to do HTTP downloads. This must be configured prior to using the
       * application instance. Yes this is a public mutable field, no I'm not going to create a
       * getter and setter just to pretend like that's not the case. */

--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -455,6 +455,9 @@ public abstract class Getdown
                 _readyToInstall = true;
                 install();
 
+                //Clean up the getdown.txt file since it could contain out of date information on the next launch.
+                Application.invalidateConfig(_app.getAppDir().getPath());
+
                 // Only launch if we aren't in silent mode. Some mystery program starting out
                 // of the blue would be disconcerting.
                 if (!_silent || _launchInSilent) {


### PR DESCRIPTION
SOF-24511 - The getdown launcher now moves the getdown.txt file to getdown.txt_old after launching the app, this fixes an issues where getdown could start up and use an out of date getdown.txt while the new one is being downloaded.