### PR TITLE
SOF-25340 - Handle new getdown url-scheme

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/EnvConfig.java
+++ b/core/src/main/java/com/threerings/getdown/data/EnvConfig.java
@@ -167,6 +167,11 @@ public final class EnvConfig {
             }
         }
 
+        if (appDir != null && appDir.startsWith(GETDOWNQ_URL)) {
+            System.setProperty("silent", "launch");
+            appDir = GETDOWN_URL + appDir.substring(GETDOWNQ_URL.length());
+        }
+
         if (appDir != null && appDir.startsWith(GETDOWN_URL)) {
             // Wait a minute this is not an appDir this is an appBase ...
             // Lets set the appDir to a folder under the home directory which is based on the appBase
@@ -271,4 +276,5 @@ public final class EnvConfig {
 
     private static final String USER_HOME_KEY = "${user.home}";
     private static final String GETDOWN_URL = "getdown://";
+    private static final String GETDOWNQ_URL = "getdownq://";
 }

--- a/launcher/pom.xml
+++ b/launcher/pom.xml
@@ -71,69 +71,35 @@
       </plugin>
 
       <plugin>
-        <groupId>com.github.wvengen</groupId>
-        <artifactId>proguard-maven-plugin</artifactId>
-        <version>2.0.14</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.4.2</version>
         <executions>
           <execution>
             <phase>package</phase>
-            <goals><goal>proguard</goal></goals>
+            <goals><goal>single</goal></goals>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <groupId>net.sf.proguard</groupId>
-            <artifactId>proguard-base</artifactId>
-            <version>6.0.3</version>
-            <scope>runtime</scope>
-          </dependency>
-        </dependencies>
         <configuration>
-          <proguardVersion>6.0.3</proguardVersion>
           <outputDirectory>${project.build.directory}</outputDirectory>
-          <outjar>${project.build.finalName}.jar</outjar>
-          <injar>${project.build.finalName}.jar</injar>
-          <assembly>
-            <inclusions>
-              <inclusion>
-                <groupId>com.threerings.getdown</groupId>
-                <artifactId>getdown-core</artifactId>
-              </inclusion>
-              <inclusion>
-                <groupId>com.samskivert</groupId>
-                <artifactId>samskivert</artifactId>
-                <filter>
-                  !**/*.java,
-                  !**/swing/RuntimeAdjust*,
-                  !**/swing/util/ButtonUtil*,
-                  !**/util/CalendarUtil*,
-                  !**/util/Calendars*,
-                  !**/util/Log4JLogger*,
-                  !**/util/PrefsConfig*,
-                  !**/util/SignalUtil*,
-                  com/samskivert/Log.class,
-                  **/samskivert/io/**,
-                  **/samskivert/swing/**,
-                  **/samskivert/text/**,
-                  **/samskivert/util/**
-                </filter>
-              </inclusion>
-              <inclusion>
-                <groupId>jregistrykey</groupId>
-                <artifactId>jregistrykey</artifactId>
-              </inclusion>
-            </inclusions>
-          </assembly>
-          <obfuscate>true</obfuscate>
-          <options>
-            <option>-keep public class com.threerings.getdown.** { *; }</option>
-            <option>-keep public class ca.beq.util.win32.registry.** { *; }</option>
-            <option>-keepattributes Exceptions, InnerClasses, Signature</option>
-          </options>
-          <libs>
-            <lib>${rt.jar.path}</lib>
-          </libs>
-          <addMavenDescriptor>false</addMavenDescriptor>
+          <finalName>${project.build.finalName}</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>com.threerings.getdown.launcher.GetdownApp</mainClass>
+            </manifest>
+            <manifestEntries>
+              <Permissions>all-permissions</Permissions>
+              <Application-Name>Getdown</Application-Name>
+              <Codebase>*</Codebase>
+              <Application-Library-Allowable-Codebase>*</Application-Library-Allowable-Codebase>
+              <Caller-Allowable-Codebase>*</Caller-Allowable-Codebase>
+              <Trusted-Library>true</Trusted-Library>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
 
@@ -157,14 +123,6 @@
           </archive>
         </configuration>
       </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <source>8</source>
-                <target>8</target>
-            </configuration>
-        </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,6 @@
 
   <name>getdown</name>
   <description>An application installer and updater.</description>
-  <url>https://github.com/threerings/getdown</url>
-  <issueManagement>
-    <url>https://github.com/threerings/getdown/issues</url>
-  </issueManagement>
 
   <licenses>
     <license>
@@ -27,23 +23,9 @@
     </license>
   </licenses>
 
-  <developers>
-    <developer>
-      <id>samskivert</id>
-      <name>Michael Bayne</name>
-      <email>mdb@samskivert.com</email>
-    </developer>
-  </developers>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-
-  <scm>
-    <connection>scm:git:git://github.com/threerings/getdown.git</connection>
-    <developerConnection>scm:git:git@github.com:threerings/getdown.git</developerConnection>
-    <url>https://github.com/threerings/getdown</url>
-  </scm>
 
   <modules>
     <module>core</module>
@@ -54,29 +36,11 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
-        <inherited>false</inherited>
-        <configuration>
-          <serverId>ossrh-releases</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <stagingProfileId>aa555c46fc37d0</stagingProfileId>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.1.0</version>
+        <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <quiet>true</quiet>
-          <show>public</show>
-          <additionalOptions>
-            <additionalOption>-Xdoclint:all</additionalOption>
-            <additionalOption>-Xdoclint:-missing</additionalOption>
-          </additionalOptions>
+          <source>8</source>
+          <target>8</target>
         </configuration>
       </plugin>
     </plugins>
@@ -89,8 +53,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.7.0</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
             <fork>true</fork>
             <showDeprecation>true</showDeprecation>
             <showWarnings>true</showWarnings>
@@ -107,83 +71,7 @@
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.0.2</version>
         </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <version>1.6</version>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>
-
-  <profiles>
-    <profile>
-      <id>eclipse</id>
-      <activation>
-        <property>
-          <name>m2e.version</name>
-        </property>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <!-- Tell m2eclipse to ignore the enforcer plugin from our parent. Otherwise it warns
-                   about not being able to run it. -->
-              <groupId>org.eclipse.m2e</groupId>
-              <artifactId>lifecycle-mapping</artifactId>
-              <version>1.0.0</version>
-              <configuration>
-                <lifecycleMappingMetadata>
-                  <pluginExecutions>
-                    <pluginExecution>
-                      <pluginExecutionFilter>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <versionRange>[1.0,)</versionRange>
-                        <goals>
-                          <goal>enforce</goal>
-                        </goals>
-                      </pluginExecutionFilter>
-                      <action>
-                        <ignore />
-                      </action>
-                    </pluginExecution>
-                  </pluginExecutions>
-                </lifecycleMappingMetadata>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-
-    <profile>
-      <id>release-sign-artifacts</id>
-      <activation>
-        <property><name>performRelease</name><value>true</value></property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <keyname>mdb@samskivert.com</keyname>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
I've added a new URL scheme `getdownq` which will launch getdown with `silent=launch` so we can use the URL launch method while also providing the option to not show any UI.